### PR TITLE
Update simplebench to enable TCO for NodeJS 8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "8.0.0"
   - "7.10.0"
 env:
   - CXX=g++-5

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ suite.run(function(err, results) {
 
 ```
 // execute
-: node --harmony --use-strict ./examples/example_node.js
+: node --harmony --harmony_tailcalls --use_strict ./examples/example_node.js
 Winner - for
 
 Results:
@@ -94,11 +94,11 @@ for - count: 2427560, ops/sec: 2427560
 forEach - count: 1491169, ops/sec: 1491169, diff: -38.57%
 ```
 
-As of Node 7.10.0, in order to enable tail call optimization you will need to start your node file with `--harmony`. If you do not utilize "use strict" in your test file, you can also start with `--use-strict` to enable it process-wide. If both settings are not exampled, it will not be possible to utilize TCO and you may need to use `bounce` to avoid max call stack.
+As of Node 7.10.0, in order to enable tail call optimization you will need to start your node file with `--harmony` and as of Node 8.0.0, you will need to also use `--harmony_tailcalls`. If you do not utilize "use strict" in your test file, you can also start with `--use_strict` to enable it process-wide. If both settings are not exampled, it will not be possible to utilize TCO and you may need to use the Suite argument `bounce` to avoid max call stack.
 
 ```
 // execute
-: node --harmony --use-strict example.js
+: node --harmony --harmony_tailcalls --use_strict example.js
 Winner - for
 
 Results:

--- a/bin/simplebench
+++ b/bin/simplebench
@@ -4,4 +4,4 @@ var child_process = require("child_process");
 
 var args = process.argv.slice(2)
 
-child_process.spawn("node", ["--harmony", "--use-strict", `${__dirname}/_simplebench.js`, ...args], { stdio : "inherit" });
+child_process.spawn("node", ["--harmony", "--use_strict", "--harmony_tailcalls", `${__dirname}/_simplebench.js`, ...args], { stdio : "inherit" });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	},
 	"engines" : { "node" : ">=7.10.0" },
 	"scripts" : {
-		"test" : "mocha $(find testing/ -name *.test.js) -R spec --colors --check-leaks --harmony"
+		"test" : "mocha $(find testing/ -name *.test.js) -R spec --colors --check-leaks --harmony --harmony_tailcalls"
 	},
 	"repository" : {
 		"type" : "git",

--- a/testing/index.test.js
+++ b/testing/index.test.js
@@ -25,11 +25,11 @@ describe(__filename, function() {
 			assert.ifError(err);
 			
 			assert.strictEqual(results.winner, "test2");
-			assert.ok(results.winnerCount >= 18 && results.winnerCount <= 22);
+			assert.ok(results.winnerCount >= 18 && results.winnerCount <= 22, results.winnerCount);
 			assert.strictEqual(results.results[0].diff, undefined);
-			assert.ok(results.results[0].opsSec >= 190 && results.results[0].opsSec <= 210);
-			assert.ok(results.results[1].diff >= -55 && results.results[1].diff <= -45);
-			assert.ok(results.results[1].opsSec >= 90 && results.results[1].opsSec <= 110);
+			assert.ok(results.results[0].opsSec >= 190 && results.results[0].opsSec <= 210, results.results[0].opsSec);
+			assert.ok(results.results[1].diff >= -55 && results.results[1].diff <= -45, results.results[1].diff);
+			assert.ok(results.results[1].opsSec >= 90 && results.results[1].opsSec <= 110, results.results[1].opsSec);
 			
 			done();
 		});
@@ -82,7 +82,7 @@ describe(__filename, function() {
 		suite.run(function(err, results) {
 			assert.ifError(err);
 			
-			assert.ok(results.results[1].diff >= -15);
+			assert.ok(results.results[1].diff >= -15, results.results[1].diff);
 			
 			done();
 		});


### PR DESCRIPTION
Apparently something changed in NodeJS 8.x that requires all 3 arguments --harmony --use_strict --harmony_tailcalls to fully enable tail call optimization. In 7.x, only --harmony --use_strict was needed.